### PR TITLE
planet not pitch black

### DIFF
--- a/Content.Shared/Light/Components/LightCycleComponent.cs
+++ b/Content.Shared/Light/Components/LightCycleComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class LightCycleComponent : Component
     /// Trench of the oscillation.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float MinLightLevel = 0f;
+    public float MinLightLevel = 0.5f; // Dune: Night should not be pitch black
 
     /// <summary>
     /// Peak of the oscillation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Planet is not pitch black at night, just changes the default value for the light cycle component